### PR TITLE
Seo changes

### DIFF
--- a/app/views/_templates/default.html
+++ b/app/views/_templates/default.html
@@ -2,12 +2,12 @@
 <html>
 <head>
   <title>
-    Pakyow Web Framework
+    Pakyow | A Realtime Web Framework for Ruby
   </title>
 
   <meta charset="utf-8">
 
-  <meta name="description" content="Pakyow: Realtime Web Framework for Ruby">
+  <meta name="description" content="Pakyow is a Ruby web framework that lets you create fantastic experiences for your users without writing any client-side code.">
 
   <link rel="stylesheet" type="text/css" media="all" href="/css/pakyow-css/reset.css">
   <link rel="stylesheet" type="text/css" media="all" href="/css/pakyow-css/structure.css">

--- a/app/views/index.slim
+++ b/app/views/index.slim
@@ -1,8 +1,8 @@
 h1.align-c
   | Build modern web applications that don't break the web.
 
-  a.margin-t.get-started href="/docs/start"
-    | Get Started
+a.margin-t.get-started href="/docs/start"
+  | Get Started
 
 .version-wrapper
   span.version-text
@@ -41,9 +41,9 @@ p.concept-text
   | We think that a democratic web presupposes a simpler web. Pakyow optimizes for simplicity, which makes it easier to start and leads to long-term productivity.
 
 .clear
-h1.align-c.margin-t
-  a.margin-t.learn-more href="/docs/overview"
-    | Learn More
+
+a.margin-t.learn-more href="/docs/overview"
+  | Learn More
 
 hr.margin-t
 .margin-t


### PR DESCRIPTION
- moved the description tag to title so that the title was longer giving us some better SEO results.
- Google was looking over our description tag because it was too short and was using the first sentence in our web page as description. It was decided upon to put the first sentence as the meta description tag to solve the "issue" on the seo ranking sites.
- Google was counting the buttons on our home page as h1 elements so I untested them.